### PR TITLE
Simplify Clarify Database class

### DIFF
--- a/tests/unit/clarify-db-test.ts
+++ b/tests/unit/clarify-db-test.ts
@@ -1,0 +1,81 @@
+import {describe, test, beforeEach, assert, afterEach} from 'vitest';
+import {rm, mkdtemp, writeFile, access} from 'fs/promises';
+import {constants} from 'fs';
+// @ts-expect-error
+import Database from '../../nodes/clarify_db';
+
+describe('clarify-db', () => {
+  let tmpUserDir!: string;
+  beforeEach(async () => {
+    tmpUserDir = await mkdtemp('userdir');
+  });
+
+  afterEach(async () => {
+    await rm(tmpUserDir, {recursive: true});
+  });
+
+  describe('#saveSignal', () => {
+    test('saves input id', async () => {
+      let one = new Database(tmpUserDir, 'node-id', 'integration-id');
+
+      await one.saveSignal('input-id', 'hash');
+
+      assert.deepEqual(one.findSignal('input-id'), 'hash');
+    });
+
+    test('supports saving multipe input ids', async () => {
+      let one = new Database(tmpUserDir, 'node-id', 'integration-id');
+
+      await one.saveSignal('input-id-01', 'hash-01');
+      await one.saveSignal('input-id-02', 'hash-02');
+
+      assert.deepEqual(one.findSignal('input-id-01'), 'hash-01');
+      assert.deepEqual(one.findSignal('input-id-02'), 'hash-02');
+    });
+
+    test('saves to disk', async () => {
+      let database = new Database(tmpUserDir, 'node-id', 'integration-id');
+
+      await database.saveSignal('input-id-01', 'hash-01');
+      assert.deepEqual(database.findSignal('input-id-01'), 'hash-01');
+
+      let another = new Database(tmpUserDir, 'node-id', 'integration-id');
+      assert.deepEqual(another.findSignal('input-id-01'), 'hash-01');
+    });
+
+    test('#saveSignal (override)', async () => {
+      let one = new Database(tmpUserDir, 'node-id', 'integration-id');
+
+      await one.saveSignal('input-id', 'hash-01');
+      await one.saveSignal('input-id', 'hash-02');
+
+      assert.deepEqual(one.findSignal('input-id'), 'hash-02');
+    });
+  });
+
+  test('#removeAll', async () => {
+    let one = new Database(tmpUserDir, 'node-id', 'integration-id');
+
+    await one.saveSignal('input-id', 'hash');
+    await one.removeAll();
+
+    assert.deepEqual(one.findSignal('input-id'), undefined);
+  });
+
+  test('#deletePreviousVersions', async () => {
+    const jsonPath = `${tmpUserDir}/clarify_db.json`;
+
+    await writeFile(jsonPath, '{"signals": []}');
+
+    new Database(tmpUserDir, 'node-id', 'integration-id');
+
+    let exist: boolean;
+    try {
+      await access(jsonPath, constants.F_OK);
+      exist = true;
+    } catch (error) {
+      exist = false;
+    }
+    assert.notOk(exist, 'Removes old versions of our database');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "baseUrl": "."
   },
-  "include": ["tests/**/*", "types/**/*"]
+  "include": ["nodes/**/*", "tests/**/*", "types/**/*"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**-test.ts'],
+    include: ['tests/**/*-test.ts'],
   },
 });


### PR DESCRIPTION
The old database class has more complicated than needed, as it supported
multiple database connections per instance. The way node-red is designed
it would never happen—as any changes it settings would trigger a deploy,
which would re-create the node. Which meant it only cached one single
instance.

If the user were to create multiple `clarify_api` nodes for the same
integration, the database would be overwritten and any changes wouldn't
be synced. To mittigate part of the problem, the `node-id` is included
in the path, which means all metadata is contained to one `clarify_api`
node. Node-red reuses the same `clarify_api` node when creating multiple
`clarify_insert` nodes pointing to the api node.

Last I chagned to format of the file, from being an array of entries to
simply a map between the `input-id` and the hash, should speed up the
lookup.