### PR TITLE
Update `@clarify/api` version 0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@clarify/node-red-contrib-clarify",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@clarify/node-red-contrib-clarify",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clarify/api": "0.2.0",
+        "@clarify/api": "~0.3.0",
         "joi": "^17.6.0",
         "lowdb": "^1.0.0",
         "node-fetch": "^2.6.7"
       },
       "devDependencies": {
-        "@clarify/api-test-support": "0.2.0",
+        "@clarify/api-test-support": "0.3.0",
         "@sinonjs/fake-timers": "^9.1.1",
         "@types/node-fetch": "^2.6.1",
         "@types/sinon": "^10.0.11",
@@ -148,11 +148,14 @@
       "dev": true
     },
     "node_modules/@clarify/api": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@clarify/api/-/api-0.2.0.tgz",
-      "integrity": "sha512-kGKtiZIaXaAcD8didHj+Gq/uLFKotL1msTlMOkqJPFwpHfuBhfPgykDYZZLcwpm6z+glr+iqWhz99zE/iUVEAg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clarify/api/-/api-0.3.0.tgz",
+      "integrity": "sha512-VvyD1A/9zfQLouNMBotLr3an3m+2CZG9x7WF2jCzSPnE4Mktgumu6VXSXq0Gu9HMgAwI73t1nOw7i2Vdo+5Rww==",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
       "peerDependencies": {
-        "node-fetch": "^3 || ^2"
+        "node-fetch": "^2"
       },
       "peerDependenciesMeta": {
         "node-fetch": {
@@ -161,16 +164,16 @@
       }
     },
     "node_modules/@clarify/api-test-support": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@clarify/api-test-support/-/api-test-support-0.2.0.tgz",
-      "integrity": "sha512-UVauUtlZ+sf0SaIiY0UcF+OMBZsxugGlEimoqPzCHxvTofMKgoaY3YQl0mv+oHKzFZH8EdhegRD3mYh2L1uQag==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clarify/api-test-support/-/api-test-support-0.3.0.tgz",
+      "integrity": "sha512-O2uXh8QZz6Kit7xkdThVhMFagBnkqM0iXnJoifx/98123fXTTCJ6xdE/tjrhyP/nrcnu/UJFFft+byEafSoEbg==",
       "dev": true,
       "dependencies": {
         "msw": "^0.41.0",
         "sinon": "^14.0.0"
       },
       "peerDependencies": {
-        "@clarify/api": "^0.2.0"
+        "@clarify/api": "^0.3.0"
       },
       "peerDependenciesMeta": {
         "@clarify/api": {
@@ -763,6 +766,17 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2380,6 +2394,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -6274,15 +6296,17 @@
       "dev": true
     },
     "@clarify/api": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@clarify/api/-/api-0.2.0.tgz",
-      "integrity": "sha512-kGKtiZIaXaAcD8didHj+Gq/uLFKotL1msTlMOkqJPFwpHfuBhfPgykDYZZLcwpm6z+glr+iqWhz99zE/iUVEAg==",
-      "requires": {}
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clarify/api/-/api-0.3.0.tgz",
+      "integrity": "sha512-VvyD1A/9zfQLouNMBotLr3an3m+2CZG9x7WF2jCzSPnE4Mktgumu6VXSXq0Gu9HMgAwI73t1nOw7i2Vdo+5Rww==",
+      "requires": {
+        "abort-controller": "^3.0.0"
+      }
     },
     "@clarify/api-test-support": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@clarify/api-test-support/-/api-test-support-0.2.0.tgz",
-      "integrity": "sha512-UVauUtlZ+sf0SaIiY0UcF+OMBZsxugGlEimoqPzCHxvTofMKgoaY3YQl0mv+oHKzFZH8EdhegRD3mYh2L1uQag==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@clarify/api-test-support/-/api-test-support-0.3.0.tgz",
+      "integrity": "sha512-O2uXh8QZz6Kit7xkdThVhMFagBnkqM0iXnJoifx/98123fXTTCJ6xdE/tjrhyP/nrcnu/UJFFft+byEafSoEbg==",
       "dev": true,
       "requires": {
         "msw": "^0.41.0",
@@ -6812,6 +6836,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -7934,6 +7966,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     }
   },
   "dependencies": {
-    "@clarify/api": "0.2.0",
+    "@clarify/api": "~0.3.0",
     "joi": "^17.6.0",
     "lowdb": "^1.0.0",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@clarify/api-test-support": "0.2.0",
+    "@clarify/api-test-support": "0.3.0",
     "@sinonjs/fake-timers": "^9.1.1",
     "@types/node-fetch": "^2.6.1",
     "@types/sinon": "^10.0.11",


### PR DESCRIPTION
Version 0.3 includes important bug fixes and performance improvements. Previously if authentication errors ever occured, it wasn't able to recover from them.

Now @clarify/api keeps the connection open during the lifetime of its client, which means it doesn't need to reestablish its connection to our API.